### PR TITLE
SmartyStreets: ensure assembling addresses from arrayref

### DIFF
--- a/lib/WebService/Async/SmartyStreets.pm
+++ b/lib/WebService/Async/SmartyStreets.pm
@@ -106,7 +106,7 @@ async sub verify {
     my $decoded = await get_decoded_data($self, $uri);
 
     $log->tracef('=> %s', $decoded);
-
+    $decoded = [ $decoded ] unless ref($decoded) eq 'ARRAY';
     return map { WebService::Async::SmartyStreets::Address->new(%$_) } @$decoded;
 }
 

--- a/lib/WebService/Async/SmartyStreets/Address.pm
+++ b/lib/WebService/Async/SmartyStreets/Address.pm
@@ -169,6 +169,7 @@ Returns 1 or 0
 
 sub accuracy_at_least {
     my ($self, $target) = @_;
+    $target = 'thoroughfare' if $target eq 'street';
     return 0 unless $self->status_at_least('partial');
     my $target_level = $accuracy_level{$target} // die 'unknown target accuracy ' . $target;
     my $actual_level = $accuracy_level{$self->address_precision} // die 'unknown accuracy ' . $self->address_precision;


### PR DESCRIPTION
`$decoded` needs to be an arrayref here to ensure we can return a map of
SmartyStreets::Address objects.