### PR TITLE
smartystreets/update_address_precision_values

### DIFF
--- a/lib/WebService/Async/SmartyStreets/Address.pm
+++ b/lib/WebService/Async/SmartyStreets/Address.pm
@@ -144,13 +144,10 @@ sub status_at_least {
 
 my %accuracy_level = (
     none => 0,
-    administrative_area => 1,
+    administrativearea => 1,
     locality => 2,
     thoroughfare => 3,
     premise => 4,
-    delivery_point => 5,
-    # I checked the API and delivery_point is indeed correct,  however we are supporting
-    # both because we are not clear on what caused this.
     deliverypoint => 5,
 );
 

--- a/t/01_unit_test.t
+++ b/t/01_unit_test.t
@@ -35,8 +35,8 @@ subtest 'Parsing test' => sub {
     
     # Check if address accuracy level check is correct
     is ($parsed_data->accuracy_at_least('locality'), 1, "Accuracy checking is correct");
-    is ($parsed_data->accuracy_at_least('delivery_point'), '', "Accuracy checking is correct");
-
+    is ($parsed_data->accuracy_at_least('administrativearea'), 1, "Accuracy checking is correct");
+    is ($parsed_data->accuracy_at_least('deliverypoint'), '', "Accuracy checking is correct");
 };
 
 done_testing;

--- a/t/02_smarty_test.t
+++ b/t/02_smarty_test.t
@@ -6,7 +6,6 @@ use Test::MockModule;
 use Test::Fatal;
 use WebService::Async::SmartyStreets;
 use Future::AsyncAwait;
-
 my $user_agent = Test::MockModule->new('Net::Async::HTTP');
 $user_agent->mock(
     GET => sub {
@@ -61,14 +60,14 @@ subtest "Call SmartyStreets" => sub {
     );
 
     my $addr = $ss->verify(%data)->get();
-
     # Check if status check is correct
     is ($addr->status_at_least('none'), 1, "Verification score is correct");
     is ($addr->status_at_least('verified'), '', "Verification score is correct");
     
     # Check if address accuracy level check is correct
     is ($addr->accuracy_at_least('locality'), 1, "Accuracy checking is correct");
-    is ($addr->accuracy_at_least('delivery_point'), '', "Accuracy checking is correct");
+    is ($addr->accuracy_at_least('administrativearea'), 1, "Accuracy checking is correct");
+    is ($addr->accuracy_at_least('deliverypoint'), '', "Accuracy checking is correct");
 };
 
 done_testing();


### PR DESCRIPTION
Update `administrative_area ` and `delivery_point` to `administrativearea` and `deliverypoint` respectively based on `address_precision` values in SmartyStreets [documentation](https://smartystreets.com/docs/cloud/international-street-api)